### PR TITLE
_isReadOnly flag treated like function call

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -52,7 +52,7 @@ export class FileOps {
             this._isReadOnly = await this.isReadOnly();
         }
 
-        if (this._isReadOnly()) {
+        if (this._isReadOnly) {
             throw new Error("File System is Read Only. Try disabling or ejecting the drive.");
         }
     }


### PR DESCRIPTION
This probably works ok in a browser but when called from a typescript project in node.js it throws a type error saying it is not a function.  FYI application is in a custom Visual Studio Code extension for CircuitPython.