### PR TITLE
Add getRuntimeStatus and getReadOnlyReason helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "version": "3.2.4",
+  "version": "3.3.0",
   "description": "A JavaScript Module to help with interfacing to the REPL on CircuitPython Devices over serial",
   "main": "repl.js",
   "exports": {

--- a/repl.js
+++ b/repl.js
@@ -896,6 +896,55 @@ export class REPL {
         return this._codeOutput;
     }
 
+    // Snapshot of the board's runtime state in a single round trip.
+    // Returns { readOnly, usbConnected }. Each field is null when the
+    // underlying CircuitPython attribute isn't available or the probe failed.
+    async getRuntimeStatus() {
+        const code = `
+try:
+    import storage
+    _ro = storage.getmount("/").readonly
+except Exception:
+    _ro = None
+try:
+    import supervisor
+    _usb = supervisor.runtime.usb_connected
+except Exception:
+    _usb = None
+print("RUNTIME_STATUS", _ro, _usb)
+`;
+        const output = await this.runCode(code);
+        const match = (output || "").match(/RUNTIME_STATUS\s+(\S+)\s+(\S+)/);
+        if (!match) {
+            return { readOnly: null, usbConnected: null };
+        }
+        return {
+            readOnly: this._parsePyBoolOrNone(match[1]),
+            usbConnected: this._parsePyBoolOrNone(match[2]),
+        };
+    }
+
+    // Best-effort classification of why the filesystem is read-only:
+    //   "not-readonly" - filesystem is writable
+    //   "usb-claim"    - host has CIRCUITPY mounted via USB MSC
+    //   "boot-py"      - read-only without USB; boot.py likely didn't remount
+    //   "hardware"     - read-only with no detectable software cause
+    //   "unknown"      - probe couldn't determine the readonly state
+    async getReadOnlyReason() {
+        const { readOnly, usbConnected } = await this.getRuntimeStatus();
+        if (readOnly === false) return "not-readonly";
+        if (readOnly === null) return "unknown";
+        if (usbConnected === true) return "usb-claim";
+        if (usbConnected === false) return "boot-py";
+        return "hardware";
+    }
+
+    _parsePyBoolOrNone(token) {
+        if (token === "True") return true;
+        if (token === "False") return false;
+        return null;
+    }
+
     getCodeOutput() {
         return this._codeOutput;
     }


### PR DESCRIPTION
## Summary

Adds two small helpers to the `REPL` class:

- **`getRuntimeStatus()`** — returns `{ readOnly, usbConnected }` for the connected board.
- **`getReadOnlyReason()`** — classifies why the filesystem is read-only.

Existing API is unchanged. `isReadOnly()` keeps the same signature. No new dependencies. Version bumped to `3.3.0`.

## Motivation

Consumers like web-editor currently re-implement small probes inline. A first-class helper makes it easy to:

- Distinguish a writable board from one whose filesystem is read-only because the host has CIRCUITPY mounted via USB MSC vs. one that was remounted read-only in `boot.py`.
- Give the user a useful next step when a write fails, instead of a generic error.

## API

### `getRuntimeStatus()`

```js
const { readOnly, usbConnected } = await repl.getRuntimeStatus();
// readOnly:     boolean | null  - storage.getmount("/").readonly
// usbConnected: boolean | null  - supervisor.runtime.usb_connected
```

Either field is `null` when the underlying attribute isn't available on the running CircuitPython build.

### `getReadOnlyReason()`

```js
const reason = await repl.getReadOnlyReason();
// "not-readonly" - filesystem is writable
// "usb-claim"    - host has CIRCUITPY mounted via USB MSC
// "boot-py"      - read-only without USB; boot.py likely didn't remount
// "hardware"     - read-only with no detectable software cause
// "unknown"      - probe couldn't determine the readonly state
```

This is best-effort. CircuitPython doesn't expose a single "why is this read-only" API, so the reason is inferred from `storage.readonly` plus `supervisor.runtime.usb_connected`.

## Implementation

The probe runs once via the existing `runCode()` path and emits a single `RUNTIME_STATUS <ro> <usb>` line that the JS side parses with a small regex.

## Backward compatibility

- `isReadOnly()` is untouched.
- New methods are additive.
- No new dependencies.

## Hardware test plan

1. **Writable + USB connected** — expect `getReadOnlyReason() === "not-readonly"`.
2. **Read-only via USB claim** (just plug in a board) — expect `"usb-claim"`.
3. **Read-only without USB** (`boot.py` calling `storage.remount("/", readonly=True)` + `storage.disable_usb_drive()`) — expect `"boot-py"`.
